### PR TITLE
Protegendo o formatador de mensagens do caracter dolar

### DIFF
--- a/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/util/PresentationMessageFormatter.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/util/PresentationMessageFormatter.java
@@ -4,6 +4,7 @@ import static com.github.ldeitos.constants.Constants.MESSAGE_KEY_PATTERN;
 import static com.github.ldeitos.constants.Constants.PARAMETER_CONTENT_GROUP;
 import static com.github.ldeitos.validation.impl.configuration.Configuration.PRESENTATION_MESSAGE;
 import static com.github.ldeitos.validation.impl.configuration.Configuration.PRESENTATION_TEMPLATE;
+import static java.util.regex.Matcher.quoteReplacement;
 import static java.util.regex.Pattern.compile;
 
 import java.util.regex.Matcher;
@@ -24,11 +25,11 @@ public class PresentationMessageFormatter {
 		if (configuration.showTemplate() && matcherTemplate.find()) {
 			Matcher matcherMessage = PRESENTATION_MESSAGE.matcher(configuration
 				.getMessagePresentationTemplate());
-			formatedMessage = matcherMessage.replaceAll(message);
+			formatedMessage = matcherMessage.replaceAll(quoteReplacement(message));
 			Matcher matcherTemplateParam = PRESENTATION_TEMPLATE.matcher(formatedMessage);
 			String msgKey = matcherTemplate.group(PARAMETER_CONTENT_GROUP);
 
-			formatedMessage = matcherTemplateParam.replaceAll(msgKey);
+			formatedMessage = matcherTemplateParam.replaceAll(quoteReplacement(msgKey));
 			matcherTemplateParam = PRESENTATION_TEMPLATE.matcher(formatedMessage);
 		}
 

--- a/extendedValidation/src/test/java/com/github/ldeitos/validation/impl/util/PresentationMessageFormatterTest.java
+++ b/extendedValidation/src/test/java/com/github/ldeitos/validation/impl/util/PresentationMessageFormatterTest.java
@@ -1,0 +1,48 @@
+package com.github.ldeitos.validation.impl.util;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.inject.Produces;
+
+import org.jglue.cdiunit.CdiRunner;
+import org.jglue.cdiunit.ProducesAlternative;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.github.ldeitos.validation.impl.configuration.ConfigInfoProvider;
+
+@RunWith(CdiRunner.class)
+@Ignore
+public class PresentationMessageFormatterTest {
+
+	@Produces
+	@ProducesAlternative
+	private ConfigInfoProvider cip = new ConfigInfoProvider() {
+		@Override
+		public String getConfigFileName() {
+			return "extendedValidation_configuredTemplateMessagePresentation.xml";
+		}
+
+		@Override
+		protected boolean isInTest() {
+			return true;
+		}
+	};
+
+	private static final String TEMPLATE = "{ER000}";
+	private static final String TEMPLATE_DOLAR = "{$$$}";
+
+	@Test
+	public void testFormatComDolarNaMensagem() {
+		assertEquals("(ER000) Erro: testando o dolar $ na mensagem.",
+				PresentationMessageFormatter.format(TEMPLATE, "Erro: testando o dolar $ na mensagem."));
+	}
+
+	@Test
+	public void testFormatComDolarNaChaveDaMensagem() {
+		assertEquals("($$$) Erro: testando o dolar na chave da mensagem.",
+				PresentationMessageFormatter.format(TEMPLATE_DOLAR, "Erro: testando o dolar na chave da mensagem."));
+	}
+
+}


### PR DESCRIPTION
Melhoria na formatação de mensagens que exibem o template protegendo do caracter '$' que é considerado especial na classe Matcher.